### PR TITLE
basic linux compatibility

### DIFF
--- a/mph/backend.py
+++ b/mph/backend.py
@@ -104,9 +104,10 @@ def versions():
         if process.returncode != 0:
             error = 'Querying install location failed.'
             logger.error(error)
-        answer = process.stdout.decode('ascii', errors='ignore').strip()
+        answer = Path(process.stdout.decode('ascii',
+                        errors='ignore').strip()).resolve()
         logger.debug(f'Reported location info is "{answer}".')
-        folder = Path(answer).parent.parent
+        folder = answer.parent.parent
         
         versions[name] = Version(major, minor, patch, build, folder)
     elif system == 'Windows':

--- a/mph/client.py
+++ b/mph/client.py
@@ -14,6 +14,7 @@ from .model import Model               # model object
 ########################################
 # Dependencies                         #
 ########################################
+import platform                        # platform information
 import jpype                           # Java bridge
 import jpype.imports                   # Java object imports
 import atexit                          # exit handler
@@ -74,7 +75,13 @@ class Client:
     """
 
     def __init__(self, cores=None, version=None, port=None, host='localhost'):
-
+        # Check system compatibility
+        system = platform.system()
+        if not (system == 'Linux' or system == 'Windows'):
+            error = (f'Unsupported operating system "{system}".')
+            logger.error(error)
+            raise NotImplementedError(error)
+        
         # Make sure this is the first (and only) client created.
         if jpype.isJVMStarted():
             error = 'Only one client can be instantiated at a time.'
@@ -84,13 +91,16 @@ class Client:
         # Determine relevant folders of the Comsol back-end.
         main = backend.folder(version)
         arch = backend.architecture()
-        jre  = main / 'java' / arch / 'jre' / 'bin'
-        jvm  = jre / 'server' / 'jvm.dll'
+        jre  = main / 'java' / arch / 'jre'
+        if system == 'Linux':
+            jvm  = jre / 'lib' / 'amd64' / 'server' / 'libjvm.so'
+        elif system == 'Windows':
+            jvm  = jre / 'bin' / 'server' / 'jvm.dll'
         api  = main / 'plugins' / '*'
 
         # Manipulate binary search path to only point to Comsol's JVM.
         path = os.environ['PATH']
-        os.environ['PATH'] = str(jre)
+        os.environ['PATH'] = str(jre / 'bin')
 
         # Set environment variable so Comsol will restrict cores at start-up.
         if cores:
@@ -130,7 +140,10 @@ class Client:
         java.setPreference('updates.update.check', 'off')
         java.setPreference('tempfiles.saving.warnifoverwriteolder', 'off')
         java.setPreference('tempfiles.recovery.autosave', 'off')
-        java.setPreference('tempfiles.recovery.checkforrecoveries', 'off')
+        try:
+            java.setPreference('tempfiles.recovery.checkforrecoveries', 'off')
+        except:
+            pass
         java.setPreference('tempfiles.saving.optimize', 'filesize')
 
         # Save setup in instance attributes.


### PR DESCRIPTION
Tested on debian 10. The user must have "comsol" in their PATH. There seems to be a problem for some reason running standalone, so it must be run like:

`# port to use for the comsol server`
`PORT = 18304`
`# start comsol server`
`comsol_server = subprocess.Popen(['comsol', 'mphserver', '--port', str(PORT)])`
`# connect to comsol server`
`client = mph.Client(cores=1, port=PORT)`