### PR TITLE
Added shell to deploy script

### DIFF
--- a/deploy/build.py
+++ b/deploy/build.py
@@ -7,11 +7,11 @@ from shutil import move
 
 root = Path(__file__).absolute().parent.parent
 
-process = run('sphinx-build docs deploy/docs', cwd=root)
+process = run('sphinx-build docs deploy/docs', cwd=root, shell=True)
 if process.returncode:
     raise RuntimeError('Error while building documentation.')
 
-process = run('flit build --format wheel', cwd=root)
+process = run('flit build --format wheel', cwd=root, shell=True)
 if process.returncode:
     raise RuntimeError('Error while building wheel.')
 move(root/'dist', root/'deploy'/'dist')


### PR DESCRIPTION
This will resolve issues on UNIX systems with the run() command calling a single string