### PR TITLE
M32 memory check on load

### DIFF
--- a/mph/client.py
+++ b/mph/client.py
@@ -181,12 +181,12 @@ class Client:
         self.port    = port
         self.java    = java
 
-    def load(self, file):
+    def load(self, file, reload=False):
         """Returns the model loaded from the given `file`."""
         file = Path(file)
 
         # Check if model is already loaded
-        if file in self.modelFiles():
+        if file in self.modelFiles() and not reload:
             logger.info('Found model in memory')
             return self.models()[self.modelFiles().index(file)]
 

--- a/mph/client.py
+++ b/mph/client.py
@@ -184,6 +184,12 @@ class Client:
     def load(self, file):
         """Returns the model loaded from the given `file`."""
         file = Path(file)
+
+        # Check if model is already loaded
+        if file in self.modelFiles():
+            logger.info('Found model in memory')
+            return self.models()[self.modelFiles().index(file)]
+
         tag = self.java.uniquetag('model')
         logger.info(f'Loading model "{file.name}".')
         model = Model(self.java.load(tag, str(file)))
@@ -213,6 +219,13 @@ class Client:
     def models(self):
         """Returns all model objects currently held in memory."""
         return [Model(self.java.model(tag)) for tag in self.java.tags()]
+
+    def modelFiles(self):
+        """
+        Returns the file pathes of all models in memory (abspath). Models without
+        files will return empty path.
+        """
+        return [Path(str(self.java.model(tag).getFilePath())) for tag in self.java.tags()]
 
     def names(self):
         """Names all models that are currently held in memory."""

--- a/mph/client.py
+++ b/mph/client.py
@@ -186,9 +186,9 @@ class Client:
         file = Path(file)
 
         # Check if model is already loaded
-        if file in self.modelFiles() and not reload:
-            logger.info('Found model in memory')
-            return self.models()[self.modelFiles().index(file)]
+        if file in self.paths() and not reload:
+            logger.info('Found model in memory, returning model from memory')
+            return self.models()[self.paths().index(file)]
 
         tag = self.java.uniquetag('model')
         logger.info(f'Loading model "{file.name}".')
@@ -220,9 +220,9 @@ class Client:
         """Returns all model objects currently held in memory."""
         return [Model(self.java.model(tag)) for tag in self.java.tags()]
 
-    def modelFiles(self):
+    def paths(self):
         """
-        Returns the file pathes of all models in memory (abspath). Models without
+        Returns the file paths of all models in memory (abspath). Models without
         files will return empty path.
         """
         return [Path(str(self.java.model(tag).getFilePath())) for tag in self.java.tags()]

--- a/mph/model.py
+++ b/mph/model.py
@@ -65,6 +65,10 @@ class Model:
             name = name.rsplit('.', maxsplit=1)[0]
         return name
 
+    def path(self):
+        """Returns the abspath of the model's mpf file"""
+        return Path(str(self.java.getFilePath()))
+
     def parameters(self):
         """
         Returns the global model parameters.


### PR DESCRIPTION
As discussed in #16, this checks model memory on load for file names and loads the model from memory if possible. This has the single culprit that an external change to the model wont be reflected. This is why I added the reload flag to load a file as a new model even if the file exists