### PR TITLE
M32 model getters

### DIFF
--- a/mph/model.py
+++ b/mph/model.py
@@ -101,6 +101,13 @@ class Model:
         tags = [str(tag) for tag in self.java.physics().tags()]
         return [str(self.java.physics(tag).name()) for tag in tags]
 
+    def boundaryConditions(self, node):
+        """Returns boundary conditions under specified physics node"""
+        physicsTags = [str(tag) for tag in self.java.physics().tags()]
+        ptag = physicsTags[self.physics().index(node)]
+        tags = [str(tag) for tag in self.java.physics(ptag).feature().tags()]
+        return [str(self.java.physics(ptag).feature(tag).name()) for tag in tags]
+
     def materials(self):
         """Returns the names of all materials."""
         tags = [str(tag) for tag in self.java.material().tags()]

--- a/mph/model.py
+++ b/mph/model.py
@@ -86,6 +86,10 @@ class Model:
         tags = [str(tag) for tag in self.java.func().tags()]
         return [str(self.java.func(tag).name()) for tag in tags]
 
+    def selections(self):
+        tags = tuple(str(tag) for tag in self.java.selection().tags())
+        return [str(self.java.selection(tag).name()) for tag in tags]
+
     def components(self):
         """Returns the names of all model components."""
         tags = [str(tag) for tag in self.java.component().tags()]

--- a/mph/model.py
+++ b/mph/model.py
@@ -105,8 +105,12 @@ class Model:
         tags = [str(tag) for tag in self.java.physics().tags()]
         return [str(self.java.physics(tag).name()) for tag in tags]
 
-    def boundaryConditions(self, node):
-        """Returns boundary conditions under specified physics node"""
+    def physic_features(self, node):
+        """
+        Returns features for a specified physics node. Those features
+        include initial conditions, boundary conditions and COMSOL specific
+        advanced modeling features connected to the physics type.
+        """
         physicsTags = [str(tag) for tag in self.java.physics().tags()]
         ptag = physicsTags[self.physics().index(node)]
         tags = [str(tag) for tag in self.java.physics(ptag).feature().tags()]


### PR DESCRIPTION
Added two new feature *getters*: Boundary conditions and selections. Both were missing and can help to get insight on how the model is built.

PS: If you don't want that many PRs like that let me know, I can have issues first or any other way which suits you better. I have also no problem if you edit / close those PRs without merge if you don't think those features are needed